### PR TITLE
Validate md5 checksum of the releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+out/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
+language: node_js
+node_js:
+  - node
 before_install:
   # install dependencies
   - travis_retry sudo apt-get update -qq
   # install libxml2-utils which contains xmllint that we will use to validate XML against schema)
   - travis_retry sudo apt-get install libxml2-utils
+  - npm install
 
 script:
   - xmllint --schema http://pkp.sfu.ca/ojs/xml/plugins.xsd ./plugins.xml --noout
+  - mkdir out && node ./scripts/extractPluginReleaseData.js
+  - bash ./scripts/checkMD5.sh < ./out/packages-md5sums.txt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+[![Build Status](https://travis-ci.org/kabaros/plugins-registry.svg?branch=master)](https://travis-ci.org/kabaros/plugins-registry)
+
+# Plugins Registry
+
+This repo contains PKP's plugins registry XML file. The live version of the file is published on: [http://pkp.sfu.ca/ojs/xml/plugins.xml](http://pkp.sfu.ca/ojs/xml/plugins.xml).
+
+## New releases
+
+- Fork this repo
+- Add the new release of your plugin to the [XML file](./plugins.xml)
+- Open a PR against this repo with the updated XML
+- Once it passes the build and it is reviewed by the maintainers, it will be published.
+
+## Checks run on the PRs
+
+- The XML is valid accoring to the schema
+- The release package URL exists on the specified URL and matches the MD5 sum.
+- [Coming] Check the contents of the gzipped file
+- [Coming] Run smoke and integration tests for the plugin release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "plugins-registry",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "plugins-registry",
+  "version": "0.0.1",
+  "description": "Plugins registry for PKP",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kabaros/plugins-registry.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/kabaros/plugins-registry/issues"
+  },
+  "homepage": "https://github.com/kabaros/plugins-registry#readme",
+  "devDependencies": {
+    "xml2js": "^0.4.23"
+  }
+}

--- a/scripts/checkMD5.sh
+++ b/scripts/checkMD5.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# The file out/packages-md5sums.txt contains a list of all plugins with their MD5 sums, in the format:
+# release_url:md5sum
+# This script goes through all the files in the list, downloads the release from release_url,
+# calculates the MD5 sum, and compare it to the md5 hash in plugins.xml 
 files_with_errors_count=0
 
 while IFS=':' read -r expected_mdsum url

--- a/scripts/checkMD5.sh
+++ b/scripts/checkMD5.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+files_with_errors_count = 0
+
+while IFS=':' read -r expected_mdsum url
+do
+    md5_result="$(curl -L -m 5 --silent $url | md5sum | awk '{print $1}')"
+    echo "✓ ${url}"
+    if [ "$md5_result" != "$expected_mdsum" ]; then
+        files_with_errors_count=$[$files_with_errors_count +1]
+        echo "✘ ${url} (Excpected: '${expected_mdsum}', Actual: '${md5_result}')"
+    fi
+done
+
+if (( $files_with_errors_count > 0 )); then
+    echo "${files_with_errors_count} plugins did not have the correct md5 sum"
+    exit 1
+fi

--- a/scripts/checkMD5.sh
+++ b/scripts/checkMD5.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-files_with_errors_count = 0
+files_with_errors_count=0
 
 while IFS=':' read -r expected_mdsum url
 do
     md5_result="$(curl -L -m 5 --silent $url | md5sum | awk '{print $1}')"
     echo "✓ ${url}"
     if [ "$md5_result" != "$expected_mdsum" ]; then
-        files_with_errors_count=$[$files_with_errors_count +1]
+        files_with_errors_count=$((files_with_errors_count+1))
         echo "✘ ${url} (Excpected: '${expected_mdsum}', Actual: '${md5_result}')"
     fi
 done
 
-if (( $files_with_errors_count > 0 )); then
-    echo "${files_with_errors_count} plugins did not have the correct md5 sum"
+if [[ "$files_with_errors_count" -gt 0 ]]; then
+    echo "$files_with_errors_count plugins did not have the correct md5 sum"
     exit 1
 fi

--- a/scripts/extractPluginReleaseData.js
+++ b/scripts/extractPluginReleaseData.js
@@ -1,0 +1,47 @@
+const { readFile, writeFile } = require('./helpers')
+const xml2js = require('xml2js')
+const parser = new xml2js.Parser()
+const https = require('https')
+const crypto = require('crypto')
+
+const { exec } = require('child_process')
+
+const args = {
+  filePath: process.argv[2] || `${__dirname}/../plugins.xml`,
+  schemaLocation: process.argv[3] || 'http://pkp.sfu.ca/ojs/xml/plugins.xsd'
+}
+
+const validateXml = async filePath => {
+  const xml = await readFile(filePath)
+  try {
+    const result = await parser.parseStringPromise(xml)
+
+    let failures = 0
+    const packages = []
+    const md5Sums = []
+
+    let packagesWithSums = ''
+
+    result.plugins.plugin.forEach(plugin => {
+      const pluginName = plugin.name[0]._
+      plugin.release.forEach(release => {
+        if (release.package.length > 1)
+          throw 'Each release should have one package'
+
+        const expectedMd5Sum = release.$.md5
+        const version = release.$.version
+        packages.push(release.package[0])
+        md5Sums.push(expectedMd5Sum)
+
+        packagesWithSums += expectedMd5Sum + ':' + release.package[0] + '\n'
+      })
+    })
+    writeFile(__dirname + '/../out/packages.txt', packages.join('\r\n'))
+    writeFile(__dirname + '/../out/md5sums.txt', md5Sums.join('\r\n'))
+    writeFile(__dirname + '/../out/packages-md5sums.txt', packagesWithSums)
+  } catch (err) {
+    throw err
+  }
+}
+
+validateXml(args.filePath)

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,0 +1,27 @@
+const fs = require('fs')
+
+const readFile = (fileName, encoding = 'utf8') => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(fileName, encoding, (err, data) => {
+      if (err) {
+        console.error(err)
+        return reject(err)
+      }
+      return resolve(data)
+    })
+  })
+}
+
+const writeFile = (fileName, content, encoding = 'utf8') => {
+  return new Promise((resolve, reject) => {
+    fs.writeFile(fileName, content, encoding, err => {
+      if (err) {
+        console.error(err)
+        return reject(err)
+      }
+      return resolve()
+    })
+  })
+}
+
+module.exports = { readFile, writeFile }


### PR DESCRIPTION
Adds a script that goes through all the releases in the registry file (`plugins.xml`), downloads them and compares their check sums with the one in the registry file.